### PR TITLE
Add admin JWT login support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ front‑end and MySQL database.
   - `JWT_SECRET_KEY` (secret key for Flask JWT sessions)
   - `MIN_DEPOSIT` (minimum deposit amount in Baht)
   - `EASY_TOKEN` and `SLIP2GO_TOKEN` (tokens for slip verification services)
+
+After creating an admin user in the database, obtain a JWT token by POSTing
+`{"username": "admin", "password": "..."}` to `/api/admin/login`. Include this
+token in the `Authorization` header as `Bearer <token>` when calling other admin
+API endpoints.
 3. Install requirements (includes Flask-SQLAlchemy):
 
 ```bash


### PR DESCRIPTION
## Summary
- integrate Flask-JWT-Extended for admin authentication
- add `/api/admin/login` endpoint returning JWT tokens
- accept either static token or JWT in `admin_required`
- document admin login flow in README

## Testing
- `python -m py_compile integrated_web.py`

------
https://chatgpt.com/codex/tasks/task_e_68641932a9008320a9dd6cb6fe76e7de